### PR TITLE
add config to pin dockerRegistryOrg

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -1,0 +1,1 @@
+dockerRegistryOwner: vfarcic


### PR DESCRIPTION
Jenkins X will determine your dockerRegistryOrg based on several different configuration locations.
The first, is `jenkins-x.yml`, after that it will look at the docker registry used.
If you're in GKE, it will use your GCP ProjectID, if you're in AWS it will be derived from ECR, and so on and so forth.

Unfortunately, this creates the behavior that the `go-demo-6` helm chart values are updated in the `jx step tag` with this `dockerRegistryOrg` value. In many cases, this will not be `vfarcic` which will be used by the Skaffold configuration building the image. Resulting in the image build being `vfarcic/go-demo-6` and the deployment (k8s resource) having the image `<myGCPProjectId>/go-demo-6` which does not exist.

The easiest way to pin the `dockerRegistryOrg` value, is this proposed `jenkins-x.yml` config file.

This also requires a PR to be merged to Jenkins X, as there's a bug with reading `dockerRegistryHost`, which is currently read from `dockerRegistryOwner`. Making a PR soon, will update this PR.